### PR TITLE
feat: Add custom label options

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,7 @@
 # Good Weekend
 
+[![Go Version](https://img.shields.io/github/go-mod/go-version/namchee/good-weekend)](https://github.com/Namchee/good-weekend)
+
 Good Weekend is a simple GitHub Action that automatically rejects any pull requests submitted on weekends. Enjoy your hassle-free weekends!
 
 ## Usage
@@ -33,7 +35,8 @@ Name | Required? | Default | Description
 ---- | --------- | ------- | -----------
 `access_token` | `true` | | [GitHub's access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) which is used to interact with GitHub's API. It is recommended to store this with [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets)
 `timezone` | `false` | `UTC` | Timezone location on [tz database](https://www.iana.org/time-zones). [Cheatsheet](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
-`message` | `false` | [See here](./action.yml) | Message to be shown on weekend pull request
+`message` | `false` | [See here](./action.yml) | Message to be shown on weekend-submitted pull requests
+`label` | `false` | `good-weekend` | Label to be added on weekend-submitted pull requests
 
 For more information, please refer to the [action metadata](./action.yml)
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Timezone location, according to tz database'
     required: false
     default: 'UTC'
+  label:
+    description: 'Label to be added on pull requests'
+    required: false
+    default: 'good-weekend'
   message:
     description: 'Reply contents'
     required: false

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ type Configuration struct {
 	token    string
 	location *time.Location
 	message  string
+	label    string
 }
 
 type Repository struct {
@@ -47,11 +48,13 @@ func getConfiguration() *Configuration {
 	}
 
 	message := os.Getenv("INPUT_MESSAGE")
+	label := os.Getenv("INPUT_LABEL")
 
 	return &Configuration{
 		token,
 		location,
 		message,
+		label,
 	}
 }
 
@@ -113,7 +116,7 @@ func main() {
 		err = closePullRequest(
 			&ctx,
 			client,
-			config.message,
+			config,
 			repository.name,
 			repository.owner,
 			pullRequest.GetNumber(),
@@ -128,7 +131,7 @@ func main() {
 func closePullRequest(
 	ctx *context.Context,
 	client *github.Client,
-	reason string,
+	config *Configuration,
 	repository string,
 	owner string,
 	number int,
@@ -139,7 +142,7 @@ func closePullRequest(
 		repository,
 		number,
 		&github.IssueComment{
-			Body: github.String(reason),
+			Body: github.String(config.message),
 		},
 	)
 
@@ -152,7 +155,7 @@ func closePullRequest(
 		owner,
 		repository,
 		number,
-		[]string{"good-weekend"},
+		[]string{config.label},
 	)
 
 	if err != nil {


### PR DESCRIPTION
## Overview

This pull request adds an option to customize labels when closing weekend-submitted pull requests.

Users can provide custom labels via `with` in the action definition.