### PR TITLE
docs: add documentation about forked repository limitations

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -11,7 +11,6 @@ Simply add this actions to your GitHub Workflows job, for example:
 ```yaml
 on:
   pull_request:
-    types: [opened] # DO NOT add other triggers!
 
 jobs:
   pr-check:
@@ -22,8 +21,6 @@ jobs:
         with:
           access_token: <YOUR_GITHUB_ACCESS_TOKEN_HERE>
 ```
-
-> Note: **DO NOT** add other triggers other than `pull_request.opened`!
 
 Please refer to [GitHub Workflows Syntax](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions) for more advanced usage.
 
@@ -39,6 +36,24 @@ Name | Required? | Default | Description
 `label` | `false` | `good-weekend` | Label to be added on weekend-submitted pull requests
 
 For more information, please refer to the [action metadata](./action.yml)
+
+## Forked Repository
+
+By default, the `pull_request` event does not allow GitHub actions to be executed from a forked repository due to [GitHub repository access exploit via GitHub Action](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/). However, this can be circumenvented changing the [event target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) from `pull_request` to `pull_request_target` which changes the execution context from the fork to the base repository. Below is the example of action configuration using `pull_request_target`.
+
+```yaml
+on:
+  pull_request_target:
+
+jobs:
+  pr-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: good-weekend
+        uses: Namchee/good-weekend@v{version}
+        with:
+          access_token: <YOUR_GITHUB_ACCESS_TOKEN_HERE>
+```
 
 ## License
 


### PR DESCRIPTION
## Overview

This pull request adds documentation about [forked repository limitations](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) and how to circumvent it.